### PR TITLE
Fix things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+Changelog
+=========
 
-# 0.0.1
-- Initial Release
+0.3.0 (2020-10-23)
+------------------
+* Improve efficiency by remove a blanket signal connect
+* Fix extraneous context switching 
+
+0.2.2 (2020-09-13)
+------------------
+* Initial working version 

--- a/rest_live/apps.py
+++ b/rest_live/apps.py
@@ -1,12 +1,5 @@
 from django.apps import AppConfig
-from django.db.models.signals import post_delete, post_save
-
-from rest_live.signals import ondelete_callback, onsave_callback
 
 
 class RestLiveConfig(AppConfig):
     name = "rest_live"
-
-    def ready(self):
-        post_save.connect(onsave_callback)
-        post_delete.connect(ondelete_callback)

--- a/rest_live/decorators.py
+++ b/rest_live/decorators.py
@@ -1,9 +1,11 @@
 from typing import Optional
 
 from django.db.models import Model
+from django.db.models.signals import post_delete, post_save
 from rest_framework import serializers
 
 from rest_live import PermissionLambda, __model_to_listeners
+from rest_live.signals import ondelete_callback, onsave_callback
 
 
 def __register_subscription(
@@ -11,6 +13,8 @@ def __register_subscription(
 ):
     model: Model = cls.Meta.model
     label = model._meta.label  # noqa
+    post_save.connect(onsave_callback, model, dispatch_uid="rest-live")
+    post_delete.connect(ondelete_callback, model, dispatch_uid="rest-live")
     if label not in __model_to_listeners:
         __model_to_listeners[label] = dict()
     __model_to_listeners[label][group_key] = (cls, check_permission)


### PR DESCRIPTION
This PR:
* Removes the blanket postsave/postdelete connections and instead only registers callbacks for models that have been subscribed to.
* Fixes the async issues seen here: pennlabs/office-hours-queue#49