### PR TITLE
Add support for filter backends

### DIFF
--- a/rest_live/consumers.py
+++ b/rest_live/consumers.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 
 from asgiref.sync import async_to_sync
 from channels.generic.websocket import JsonWebsocketConsumer
+from django.http import Http404
+from rest_framework.exceptions import NotAuthenticated, PermissionDenied
 
 from rest_live import get_group_name, DELETED, UPDATED, CREATED
 from rest_live.mixins import RealtimeMixin
@@ -113,7 +115,6 @@ class SubscriptionConsumer(JsonWebsocketConsumer):
             view = self.registry[model_label].from_scope(
                 view_action, self.scope, view_kwargs, query_params
             )
-            model = view.get_model_class()
 
             # Check to make sure client has permissions to make this subscription.
             has_permission = True
@@ -122,23 +123,20 @@ class SubscriptionConsumer(JsonWebsocketConsumer):
                     view.request, view
                 )
 
-            # Retrieve actions must check has_object_permission as well.
+            # Retrieve actions use get_object() to check object permissions as well.
             if view.action == "retrieve":
+                view.kwargs.setdefault(view.lookup_field, lookup_value)
                 try:
-                    instance = view.get_queryset().get(
-                        **{view.lookup_field: lookup_value}
+                    view.get_object()
+                except Http404:
+                    self.send_error(
+                        request_id,
+                        404,
+                        "Instance not found. Make sure 'lookup_by' is set to a valid ID",
                     )
-                except model.DoesNotExist:
-                    self.send_error(request_id, 404, "Instance not found.")
                     return
-
-                for permission in view.get_permissions():
-                    has_permission = (
-                        has_permission
-                        and permission.has_object_permission(
-                            view.request, view, instance
-                        )
-                    )
+                except (NotAuthenticated, PermissionDenied):
+                    has_permission = False
 
             if not has_permission:
                 self.send_error(
@@ -192,10 +190,10 @@ class SubscriptionConsumer(JsonWebsocketConsumer):
             ]
             self.groups.remove(
                 group_name
-            )  # Removes the first occurance of this group name.
+            )  # Removes the first occurrence of this group name.
             if (
                 group_name not in self.groups
-            ):  # If there are no more occurances, unsubscribe to the channel layer.
+            ):  # If there are no more occurrences, unsubscribe to the channel layer.
                 async_to_sync(self.channel_layer.group_discard)(
                     group_name, self.channel_name
                 )
@@ -226,7 +224,7 @@ class SubscriptionConsumer(JsonWebsocketConsumer):
 
             is_existing_instance = instance_pk in subscription.pks_in_queryset
             try:
-                instance = view.get_queryset().get(pk=instance_pk)
+                instance = view.filter_queryset(view.get_queryset()).get(pk=instance_pk)
                 action = UPDATED if is_existing_instance else CREATED
             except model.DoesNotExist:
                 if not is_existing_instance:

--- a/rest_live/mixins.py
+++ b/rest_live/mixins.py
@@ -74,7 +74,6 @@ class RealtimeMixin(object):
         self.action_map = dict()
         self.args = []
         self.kwargs = view_kwargs
-        self.action = viewset_action  # TODO: custom subscription actions?
 
         base_request = AsgiRequest(
             {**scope, "method": "GET", "query_string": urlencode(query_params)},
@@ -85,4 +84,5 @@ class RealtimeMixin(object):
         base_request.session = scope.get("session", None)
 
         self.request = self.initialize_request(base_request)
+        self.action = viewset_action  # TODO: custom subscription actions?
         return self

--- a/test_app/views.py
+++ b/test_app/views.py
@@ -1,8 +1,7 @@
-from rest_framework import viewsets
+from rest_framework import viewsets, filters
 from rest_framework.generics import GenericAPIView
 from rest_framework.permissions import (
     IsAuthenticated,
-    DjangoModelPermissions,
     BasePermission,
 )
 
@@ -19,6 +18,8 @@ from test_app.serializers import (
 class TodoViewSet(GenericAPIView, RealtimeMixin):
     queryset = Todo.objects.all()
     serializer_class = TodoSerializer
+    filter_backends = [filters.SearchFilter]
+    search_fields = ["text"]
 
 
 class ConditionalTodoViewSet(viewsets.ModelViewSet, RealtimeMixin):

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -276,6 +276,54 @@ class ViewKwargTests(RestLiveTestCase):
         )
 
 
+class QueryParamsTests(RestLiveTestCase):
+    """
+    Tests to ensure that query (GET) params passed along with subscriptions are
+    handled properly. This ensures compatibility with DRF filter backends.
+    """
+
+    async def asyncSetUp(self):
+        router = RealtimeRouter()
+        router.register(TodoViewSet)
+        self.client = APICommunicator(router.as_consumer(), "/ws/subscribe/")
+        connected, _ = await self.client.connect()
+        self.assertTrue(connected)
+        self.list = await db(List.objects.create)(name="test list")
+
+    async def asyncTearDown(self):
+        await self.client.disconnect()
+
+    @async_test
+    async def test_list(self):
+        request_id = await self.subscribe_to_list(params={"search": "hello"})
+
+        todo = await self.make_todo("hello world")
+        await self.assertReceivedBroadcastForTodo(todo, CREATED, request_id)
+
+        await db(todo.save)()
+        await self.assertReceivedBroadcastForTodo(todo, UPDATED, request_id)
+
+        todo.text = "goodbye world"  # No longer matches search query
+        await db(todo.save)()
+        await self.assertReceivedBroadcastForTodo(todo, DELETED, request_id)
+
+        # Make sure new ToDos that don't match the query are never broadcasted
+        await self.make_todo("no match")
+        self.assertTrue(await self.client.receive_nothing())
+
+    @async_test
+    async def test_retrieve(self):
+        self.todo = await self.make_todo("hello world")
+        request_id = await self.subscribe_to_todo(params={"search": "hello"})
+
+        await db(self.todo.save)()
+        await self.assertReceivedBroadcastForTodo(self.todo, UPDATED, request_id)
+
+        self.todo.text = "goodbye world"  # No longer matches the query
+        await db(self.todo.save)()
+        await self.assertReceivedBroadcastForTodo(self.todo, DELETED, request_id)
+
+
 class QuerysetFetchTest(RestLiveTestCase):
     """
     Tests to make sure that subscriptions properly respect the queryset on the view.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -81,14 +81,16 @@ class RestLiveTestCase(TransactionTestCase):
 
         return response
 
-    async def subscribe_to_todo(self, client=None, error=None, kwargs=None):
+    async def subscribe_to_todo(
+        self, client=None, error=None, kwargs=None, params=None
+    ):
         if kwargs is None:
             kwargs = dict()
         if client is None:
             client = self.client
 
         request_id = await self.subscribe(
-            "test_app.Todo", "retrieve", self.todo.pk, client, kwargs
+            "test_app.Todo", "retrieve", self.todo.pk, client, kwargs, params
         )
         if error is None:
             self.assertTrue(await client.receive_nothing())

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     py38-django{31}
 
 [testenv]
-commands = pytest --cov=rest_live --cov-append --junitxml=test-results/tests.xml
+commands = pytest --cov=rest_live --cov-append --cov-report term-missing:skip-covered --junitxml=test-results/tests.xml
 setenv =
     DJANGO_SETTINGS_MODULE = tests.settings
     PYTHONPATH = {toxinidir}


### PR DESCRIPTION
This adds support for DRF filter backends. The tests use DRF's built-in `SearchFilter` backend, but the logic is the same for more complicated backends like those based on `django-filter`. It all boils down to wrapping `get_queryset` with `filter_queryset`.

I also snuck in some misc bugfixes for issues we encountered with rest-live. 